### PR TITLE
Fix compiler warnings - Round 1

### DIFF
--- a/CommonVersionInfo/BuildVersion.cs
+++ b/CommonVersionInfo/BuildVersion.cs
@@ -16,6 +16,13 @@ namespace CommonVersionInfo
         public int Build { get; set; }
         public string Mode { get; set; }
 
+
+        public BuildVersion()
+        {
+            Mode = string.Empty;
+        }
+ 
+
         public override string ToString()
         {
             return $"{MajorVersion}.{MinorVersion}.{Revision}.{Build}-{Mode}";

--- a/LutheRun/LSBElementHymn.cs
+++ b/LutheRun/LSBElementHymn.cs
@@ -276,7 +276,6 @@ namespace LutheRun
                 string title = "Hymn";
                 string name = match.Groups["name"]?.Value.Trim() ?? "";
                 string number = match.Groups["number"]?.Value.Trim().Length > 0 ? ("LSB " + match.Groups["number"]?.Value.Trim()) : "";
-                string tune = "";
                 string copyright = Copyright;
 
                 //sb.AppendLine($"/// \"{title}\", \"{name}\", \"{tune}\", \"{number}\", \"{copyright}\"");

--- a/SlideCreater/MainWindow.xaml.cs
+++ b/SlideCreater/MainWindow.xaml.cs
@@ -556,7 +556,7 @@ namespace SlideCreater
                     assetItemCtrl.OnRenameAssetRequest += AssetItemCtrl_OnRenameAssetRequest;
                     AssetList.Children.Add(assetItemCtrl);
                 }
-                catch (FileNotFoundException ex)
+                catch (FileNotFoundException)
                 {
                     loaderrors = true;
                     missingassets.Add(asset.Name);
@@ -743,7 +743,7 @@ namespace SlideCreater
                 {
                     ShowProjectAssets();
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     MessageBox.Show("Failed to load project assets");
                     Assets.Clear();

--- a/SwitcherControl/BMDSwitcher/BMDSwitcherManager.cs
+++ b/SwitcherControl/BMDSwitcher/BMDSwitcherManager.cs
@@ -35,7 +35,6 @@ namespace IntegratedPresenter
         private IBMDSwitcherMediaPlayer _BMDSwitcherMediaPlayer1;
         private IBMDSwitcherMediaPlayer _BMDSwitcherMediaPlayer2;
         private IBMDSwitcherMediaPool _BMDSwitcherMediaPool;
-        private IBMDSwitcherKeyDVEParameters _BMDSwitcherDVEParameters;
         private IBMDSwitcherKeyFlyParameters _BMDSwitcherFlyKeyParamters;
         private IBMDSwitcherTransitionParameters _BMDSwitcherTransitionParameters;
 
@@ -48,7 +47,7 @@ namespace IntegratedPresenter
         private List<InputMonitor> _inputMonitors = new List<InputMonitor>();
         private SwitcherFlyKeyMonitor _flykeyMonitor;
         private SwitcherTransitionMonitor _transitionMontitor;
-        // prehaps don't need to monitor multiviewer
+        // perhaps don't need to monitor multiviewer
         // for now won't have mediaplayer monitors
 
         private BMDSwitcherState _state;

--- a/Xenon/Compiler/AST/XenonASTStitchedHymn.cs
+++ b/Xenon/Compiler/AST/XenonASTStitchedHymn.cs
@@ -184,9 +184,7 @@ namespace Xenon.Compiler.AST
 
             }
 
-            bool unconfidentaboutrefrain = false;
             bool unconfidentaboutlinetype = false;
-            const int refrainheight = 136;
             LSBImageResource linemusic = null;
             List<LSBImageResource> linetexts = new List<LSBImageResource>();
             List<(LSBImageResource music, List<LSBImageResource> words)> CollatedLines = new List<(LSBImageResource music, List<LSBImageResource> words)>();

--- a/Xenon/Compiler/Lexer.cs
+++ b/Xenon/Compiler/Lexer.cs
@@ -40,8 +40,6 @@ namespace Xenon.Compiler
 
         public int MaxChecks { get; private set; }
 
-        private bool nextTokenIsEscaped = false;
-
         private int peeks = 0;
         private int peeknexts = 0;
         private int inspections = 0;
@@ -402,7 +400,7 @@ namespace Xenon.Compiler
             catch (Exception ex)
             {
                 Logger.Log(new XenonCompilerMessage() { ErrorName = "Expecting missing token", ErrorMessage = $"Expecting token <'{test}'>.\r\nAdditional Info: {errormessage}", Generator = "Lexer.ConsumeUntil", Inner = ex.Message, Level = XenonCompilerMessageType.Error, Token = CurrentToken });
-                throw ex;
+                throw;
             }
 
             //return sb.ToString();
@@ -435,7 +433,7 @@ namespace Xenon.Compiler
                     Level = XenonCompilerMessageType.Error,
                     Token = CurrentToken
                 });
-                throw ex;
+                throw;
             }
             return sb.ToString();
         }
@@ -495,7 +493,7 @@ namespace Xenon.Compiler
                 catch (Exception ex)
                 {
                     Logger.Log(new XenonCompilerMessage() { ErrorName = "Bad parameter", ErrorMessage = $"Mal-formed parameter {helpmsg}.", Generator = "Lexer.ConsumeArgList", Inner = ex.Message, Level = XenonCompilerMessageType.Error, Token = CurrentToken });
-                    throw ex;
+                    throw;
                 }
 
 

--- a/Xenon/Compiler/XenonBuildService.cs
+++ b/Xenon/Compiler/XenonBuildService.cs
@@ -34,9 +34,9 @@ namespace Xenon.Compiler
                     {
                         Project = await compiler.Compile(proj, inputtext, Assets, progress);
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
-                        throw ex;
+                        throw;
                     }
                 });
             }
@@ -165,6 +165,12 @@ namespace Xenon.Compiler
                 }
 
                 await Task.WhenAll(slidetasks);
+                
+                if (failedslides > 0)
+                {
+                    Messages.Add(new XenonCompilerMessage() { ErrorMessage = $"Rendering failed to render {failedslides} slides.", ErrorName = "Failed to Render Slides", Level = XenonCompilerMessageType.Error });
+                }
+                
                 return slides.ToList();
             }
             catch (Exception ex)
@@ -172,10 +178,7 @@ namespace Xenon.Compiler
                 Messages.Add(new XenonCompilerMessage() { ErrorMessage = ex.ToString(), ErrorName = "Error Rendering Project", Level = XenonCompilerMessageType.Error });
                 return new List<RenderedSlide>();
             }
-            if (failedslides > 0)
-            {
-                Messages.Add(new XenonCompilerMessage() { ErrorMessage = $"Rendering failed to render {failedslides} slides.", ErrorName = "Failed to Render Slides", Level = XenonCompilerMessageType.Error });
-            }
+
         }
 
 

--- a/Xenon/LayoutEngine/LiturgyVerseLayoutEngine.cs
+++ b/Xenon/LayoutEngine/LiturgyVerseLayoutEngine.cs
@@ -62,13 +62,10 @@ namespace Xenon.LayoutEngine
 
             List<string> line = new List<string>();
 
-            bool skipnext = false;
-
             foreach (var word in words)
             {
                 if (Escape.Contains(word))
                 {
-                    skipnext = true;
                     continue;
                 }
                 // ignore newlines
@@ -85,7 +82,6 @@ namespace Xenon.LayoutEngine
                     // use space instead
                     line.Add(" ");
                 }
-                skipnext = false;
             }
             Lines.Add(finalizeline(line));
 

--- a/Xenon/Renderer/ISlideRenderer.cs
+++ b/Xenon/Renderer/ISlideRenderer.cs
@@ -57,7 +57,7 @@ namespace Xenon.Renderer
                 {
                     return JsonSerializer.Deserialize<LayoutType>((string)info);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return GetDefaultInfo();
                 }

--- a/Xenon/Renderer/PrefabSlideRenderer.cs
+++ b/Xenon/Renderer/PrefabSlideRenderer.cs
@@ -95,7 +95,7 @@ namespace Xenon.Renderer
                 }
 
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 res.Bitmap = bmp;
                 string tmp = "KEY ERROR on data attribute";
@@ -106,7 +106,7 @@ namespace Xenon.Renderer
                     tmp = ((PrefabSlides)a).Convert();
                 }
                 messages.Add(new XenonCompilerMessage() { Level = XenonCompilerMessageType.Error, ErrorMessage = $"Requested prefab image not loaded. While rendering slide {slide.Number}", ErrorName = "Prefab not found", Token = tmp });
-                throw ex;
+                throw;
             }
 
             if (src != null)

--- a/Xenon/Renderer/TitledLiturgyVerseSlideRenderer.cs
+++ b/Xenon/Renderer/TitledLiturgyVerseSlideRenderer.cs
@@ -195,9 +195,6 @@ namespace Xenon.Renderer
             float interspace = (layout.ContentTextbox.Textbox.Size.Height - alltextheight) / (Lines.Count + 1);
 
             float vspace = interspace;
-            int linenum = 0;
-
-            string lastspeaker = "";
 
             Font flsbregular = new Font("LSBSymbol", layout.ContentTextbox.Font.Size, (FontStyle)layout.ContentTextbox.Font.Style);
 

--- a/Xenon/SlideAssembly/Project.cs
+++ b/Xenon/SlideAssembly/Project.cs
@@ -134,7 +134,6 @@ namespace Xenon.SlideAssembly
         }
 
         private string _loadTmpPath = "";
-        private bool disposedValue;
 
         public string LoadTmpPath { get => _loadTmpPath; }
 

--- a/build.py
+++ b/build.py
@@ -7,7 +7,7 @@ def main():
     parser = argparse.ArgumentParser(description="Generate Official Builds")
     parser.add_argument("mode", type=str, default="Release", help="build mode: Experimental/Release etc.")
 
-    args = parser.parse_args();
+    args = parser.parse_args()
     print(args.mode)
 
     print("starting builds...")


### PR DESCRIPTION
Reduced from 41 to 24 warnings (VS2022).
* Remove unused variables
* Move unreachable code
* Fix rethrown exceptions