### PR TITLE
fix: apostles creed indentation - third article

### DIFF
--- a/LutheRun/PrefabBlobs/ApostlesCreed.txt
+++ b/LutheRun/PrefabBlobs/ApostlesCreed.txt
@@ -23,7 +23,7 @@ $>$>`     From thence He will come to judge the living and the dead.
 $>$>`
 $>$>`I believe in the Holy Spirit,
 $>$>`     the holy Christian Church,
-$>$>`          the communion of saints,
+$>$>`     the communion of saints,
 $>$>`     the forgiveness of sins,
 $>$>`     the resurrection of the body,
 $>$>`     and the life everlasting. Amen.


### PR DESCRIPTION
Remove extra indentation in third article of creed.  Match rendition in hymnals. For example: 
![image](https://i.pinimg.com/736x/df/ee/46/dfee463de375da36634a4c1ce150573a--apostles-creed-lutheran.jpg)